### PR TITLE
JDK-8326951 Missing @since Tags

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -7919,6 +7919,7 @@ assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
      *                                  handles is not {@code int}, or if the types of
      *                                  the fallback handle and all of target handles are
      *                                  not the same.
+     * @since 17
      */
     public static MethodHandle tableSwitch(MethodHandle fallback, MethodHandle... targets) {
         Objects.requireNonNull(fallback);

--- a/src/java.base/share/classes/java/lang/reflect/MalformedParameterizedTypeException.java
+++ b/src/java.base/share/classes/java/lang/reflect/MalformedParameterizedTypeException.java
@@ -50,6 +50,7 @@ public class MalformedParameterizedTypeException extends RuntimeException {
      * Constructs a {@code MalformedParameterizedTypeException} with
      * the given detail message.
      * @param message the detail message; may be {@code null}
+     * @since 10
      */
     public MalformedParameterizedTypeException(String message) {
         super(message);

--- a/src/java.base/share/classes/java/nio/MappedByteBuffer.java
+++ b/src/java.base/share/classes/java/nio/MappedByteBuffer.java
@@ -410,6 +410,7 @@ public abstract sealed class MappedByteBuffer
      * of this buffer that the returned buffer represents, namely
      * {@code [index,index+length)}, where {@code index} and {@code length} are
      * assumed to satisfy the preconditions.
+     * @since 13
      */
     @Override
     public abstract MappedByteBuffer slice(int index, int length);

--- a/src/java.base/share/classes/java/util/Properties.java
+++ b/src/java.base/share/classes/java/util/Properties.java
@@ -185,6 +185,7 @@ public class Properties extends Hashtable<Object,Object> {
      *         accommodate this many elements
      * @throws IllegalArgumentException if the initial capacity is less than
      *         zero.
+     * @since 10
      */
     public Properties(int initialCapacity) {
         this(null, initialCapacity);

--- a/src/java.base/share/classes/java/util/concurrent/ThreadLocalRandom.java
+++ b/src/java.base/share/classes/java/util/concurrent/ThreadLocalRandom.java
@@ -506,6 +506,7 @@ public final class ThreadLocalRandom extends Random {
      * {@inheritDoc}
      * @throws IllegalArgumentException {@inheritDoc}
      * @implNote {@inheritDoc}
+     * @since 17
      */
     @Override
     public float nextFloat(float bound) {
@@ -516,6 +517,7 @@ public final class ThreadLocalRandom extends Random {
      * {@inheritDoc}
      * @throws IllegalArgumentException {@inheritDoc}
      * @implNote {@inheritDoc}
+     * @since 17
      */
     @Override
     public float nextFloat(float origin, float bound) {

--- a/src/java.base/share/classes/java/util/zip/Deflater.java
+++ b/src/java.base/share/classes/java/util/zip/Deflater.java
@@ -336,6 +336,7 @@ public class Deflater {
      * @param dictionary the dictionary data bytes
      * @see Inflater#inflate
      * @see Inflater#getAdler()
+     * @since 11
      */
     public void setDictionary(ByteBuffer dictionary) {
         synchronized (zsRef) {


### PR DESCRIPTION
I added `@since` tags for methods/constructors that do not match the `@since` of the enclosing class